### PR TITLE
fix: build 에러, 따옴표 =>  HTML 엔티티로 변환

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -8,7 +8,7 @@ const page = () => {
           <h1 className="text-4xl font-bold">peak</h1>
         </Link>
         <div className="flex flex-col gap-3">
-          <p>"이곳에서 세상의 의미 있는 세일즈가 이루어지길."</p>
+          <p>&ldquo;이곳에서 세상의 의미 있는 세일즈가 이루어지길.&rdquo;</p>
           <p>Meet for Deal</p>
         </div>
       </section>


### PR DESCRIPTION
- build 시 따옴표 변환하라는 경고문이 있어 HTML 엔티티로 수정
```tsx
<p>"이곳에서 세상의 의미 있는 세일즈가 이루어지길."</p>
<p>&ldquo;이곳에서 세상의 의미 있는 세일즈가 이루어지길.&rdquo;</p>
```