### PR TITLE
feat: 칸반 보드 단계별 D&D 이동 가능, 드래그 오류 해결

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,4 +1,4 @@
 /** @type {import('next').NextConfig} */
-const nextConfig = {};
+const nextConfig = { reactStrictMode: false, swcMinify: true };
 
 export default nextConfig;

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,7 @@
 
 import Header from "@/components/Header";
 import Menu from "@/components/Menu";
-import { LEAD_ITEM_STATUS } from "@/types/lead";
+import { LEAD_ITEM_STATUS, LeadKey, LeadTitle } from "@/types/lead";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import {
@@ -25,7 +25,7 @@ const LEAD_ITEMS = {
   lost: [],
 };
 
-const COLUMN_TITLES = {
+const COLUMN_TITLES: Record<LeadKey, LeadTitle> = {
   leadGen: {
     name: "Lead Gen",
     info: "제안 전",
@@ -99,10 +99,10 @@ export default function Home() {
                       >
                         <div className="p-4">
                           <h2 className="text-lg font-bold">
-                            {COLUMN_TITLES[key].name}
+                            {COLUMN_TITLES[key as LeadKey].name}
                           </h2>
                           <p className="text-sm text-neutral-500">
-                            {COLUMN_TITLES[key].info}
+                            {COLUMN_TITLES[key as LeadKey].info}
                           </p>
                         </div>
                         {leadItems[key as LEAD_ITEM_STATUS].map(

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import Header from "@/components/Header";
 import Menu from "@/components/Menu";
+import { LEAD_ITEM_STATUS } from "@/types/lead";
 import Link from "next/link";
 import { useEffect, useState } from "react";
 import {
@@ -10,23 +11,6 @@ import {
   Draggable,
   DropResult,
 } from "react-beautiful-dnd";
-
-export type LEAD_ITEM_STATUS =
-  | "leadGen"
-  | "proposal"
-  | "negotiation"
-  | "closed"
-  | "lost";
-
-export type LEAD_ITEM = {
-  id: string;
-  status: LEAD_ITEM_STATUS;
-  title: string;
-};
-
-export type LEAD_ITEMS = {
-  [key in LEAD_ITEM_STATUS]: LEAD_ITEM[];
-};
 
 const LEAD_ITEMS = {
   leadGen: [

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,7 +3,7 @@
 import Header from "@/components/Header";
 import Menu from "@/components/Menu";
 import Link from "next/link";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   DragDropContext,
   Droppable,
@@ -36,6 +36,7 @@ const LEAD_STATES = [
 ];
 
 export default function Home() {
+  const [enabled, setEnabled] = useState(false);
   const [leadItems, setItems] = useState(LEAD_ITEMS);
 
   const onDragEnd = (result: DropResult) => {
@@ -48,21 +49,34 @@ export default function Home() {
     setItems(reorderedItems);
   };
 
+  useEffect(() => {
+    const animation = requestAnimationFrame(() => setEnabled(true));
+
+    return () => {
+      cancelAnimationFrame(animation);
+      setEnabled(false);
+    };
+  }, []);
+
+  if (!enabled) {
+    return null;
+  }
+
   return (
     <div>
       <Header />
       <main className="flex">
         <Menu />
-        <section className="w-full p-4 bg-white">
-          <h1 className="text-2xl font-black border-b-2 border-black border-solid">
+        <section className="w-full bg-white p-4">
+          <h1 className="border-b-2 border-solid border-black text-2xl font-black">
             HOME
           </h1>
-          <div className="flex justify-between p-4 bg-neutral-100">
+          <div className="flex justify-between bg-neutral-100 p-4">
             <DragDropContext onDragEnd={onDragEnd}>
               {LEAD_STATES.map((state) => (
                 <div
                   key={state.id}
-                  className="bg-white border border-solid rounded border-neutral-300"
+                  className="rounded border border-solid border-neutral-300 bg-white"
                 >
                   <div className="p-4">
                     <h2 className="text-lg font-bold">{state.name}</h2>
@@ -73,7 +87,7 @@ export default function Home() {
                       <div
                         {...provided.droppableProps}
                         ref={provided.innerRef}
-                        className="border border-red-500 border-solid rounded"
+                        className="rounded border border-solid border-red-500"
                       >
                         {leadItems
                           .filter((item) => item.stateId === state.id)
@@ -108,7 +122,7 @@ export default function Home() {
             </DragDropContext>
           </div>
           <Link href="/lead">
-            <button className="p-3 mt-4 border border-solid rounded bg-neutral-300">
+            <button className="mt-4 rounded border border-solid bg-neutral-300 p-3">
               리드 아이템 페이지로
             </button>
           </Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,29 +11,6 @@ import {
   DropResult,
 } from "react-beautiful-dnd";
 
-// const LEAD_STATES = [
-//   {
-//     id: "leadGen",
-//     name: "Lead Gen",
-//     info: "제안 전",
-//     items: [
-//       { id: "1", content: "치과" },
-//       { id: "2", content: "정형외과" },
-//       { id: "3", content: "내과" },
-//       { id: "4", content: "한의원" },
-//     ],
-//   },
-//   {
-//     id: "proposal",
-//     name: "Proposal",
-//     info: "제안 중",
-//     items: [{ id: "4", content: "한의원" }],
-//   },
-//   { id: "negotiation", name: "Negotiation", info: "협상 중" },
-//   { id: "closed", name: "Closed", info: "계약 완료" },
-//   { id: "lost", name: "Lost", info: "계약 취소" },
-// ];
-
 export type LEAD_ITEM_STATUS =
   | "leadGen"
   | "proposal"

--- a/src/types/lead.ts
+++ b/src/types/lead.ts
@@ -14,3 +14,15 @@ export type LEAD_ITEM = {
 export type LEAD_ITEMS = {
   [key in LEAD_ITEM_STATUS]: LEAD_ITEM[];
 };
+
+export type LeadKey =
+  | "leadGen"
+  | "proposal"
+  | "negotiation"
+  | "closed"
+  | "lost";
+
+export interface LeadTitle {
+  name: string;
+  info: string;
+}

--- a/src/types/lead.ts
+++ b/src/types/lead.ts
@@ -1,0 +1,16 @@
+export type LEAD_ITEM_STATUS =
+  | "leadGen"
+  | "proposal"
+  | "negotiation"
+  | "closed"
+  | "lost";
+
+export type LEAD_ITEM = {
+  id: string;
+  status: LEAD_ITEM_STATUS;
+  title: string;
+};
+
+export type LEAD_ITEMS = {
+  [key in LEAD_ITEM_STATUS]: LEAD_ITEM[];
+};


### PR DESCRIPTION
- stricMode 해제
- requestAnimationFrame 호출 이후 DND 컴포넌트 렌더링 되도록
- Lead Gen / Propasal / Negotiation / Closed / Lead Gen 다섯 단계 D&D 가능

🔗 https://velog.io/@bepyan/react-beautiful-dnd%EB%A1%9C-TODO-%EB%A6%AC%EC%8A%A4%ED%8A%B8-%EB%BD%80%EA%B0%9C%EA%B8%B0